### PR TITLE
Fix admin bots route

### DIFF
--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -3,6 +3,6 @@ const router = express.Router()
 
 router.use('/admin/users', require('./admin/users'))
 router.use('/admin/customers', require('./admin/customers'))
-router.use('/admin/customers', require('./admin/bots'))
+router.use('/admin/bots', require('./admin/bots'))
 
 module.exports = router


### PR DESCRIPTION
## Summary
- keep bots registered under `/admin/bots`
- restore original update error messages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684008e679888330916b1cdfa9c95214