### PR TITLE
Add sales table support

### DIFF
--- a/api/src/controllers/admin/sale-controller.js
+++ b/api/src/controllers/admin/sale-controller.js
@@ -1,0 +1,115 @@
+const sequelizeDb = require('../../models/sequelize')
+const Sale = sequelizeDb.Sale
+const Op = sequelizeDb.Sequelize.Op
+
+exports.create = async (req, res, next) => {
+  try {
+    const data = await Sale.create(req.body)
+    res.status(200).send(data)
+  } catch (err) {
+    if (err.name === 'SequelizeValidationError') {
+      err.statusCode = 422
+    }
+    next(err)
+  }
+}
+
+exports.findAll = async (req, res, next) => {
+  try {
+    const page = parseInt(req.query.page) || 1
+    const limit = parseInt(req.query.size) || 10
+    const offset = (page - 1) * limit
+    const whereStatement = {}
+
+    for (const key in req.query) {
+      if (req.query[key] !== '' && req.query[key] !== 'null' && key !== 'page' && key !== 'size') {
+        whereStatement[key] = { [Op.substring]: req.query[key] }
+      }
+    }
+
+    const condition = Object.keys(whereStatement).length > 0
+      ? { [Op.and]: [whereStatement] }
+      : {}
+
+    const result = await Sale.findAndCountAll({
+      where: condition,
+      attributes: ['id', 'totalBasePrice', 'totalTax', 'totalPrice', 'issueDate', 'createdAt', 'updatedAt'],
+      limit,
+      offset,
+      order: [['createdAt', 'DESC']]
+    })
+
+    result.meta = {
+      total: result.count,
+      pages: Math.ceil(result.count / limit),
+      currentPage: page,
+      size: limit
+    }
+
+    res.status(200).send(result)
+  } catch (err) {
+    next(err)
+  }
+}
+
+exports.findOne = async (req, res, next) => {
+  try {
+    const id = req.params.id
+    const data = await Sale.findByPk(id)
+
+    if (!data) {
+      const err = new Error()
+      err.message = `No se puede encontrar el elemento con la id=${id}.`
+      err.statusCode = 404
+      throw err
+    }
+
+    res.status(200).send(data)
+  } catch (err) {
+    next(err)
+  }
+}
+
+exports.update = async (req, res, next) => {
+  try {
+    const id = req.params.id
+    const [numberRowsAffected] = await Sale.update(req.body, { where: { id } })
+
+    if (numberRowsAffected !== 1) {
+      const err = new Error()
+      err.message = `No se puede actualizar el elemento con la id=${id}. Tal vez no se ha encontrado.`
+      err.statusCode = 404
+      throw err
+    }
+
+    res.status(200).send({
+      message: 'El elemento ha sido actualizado correctamente.'
+    })
+  } catch (err) {
+    if (err.name === 'SequelizeValidationError') {
+      err.statusCode = 422
+    }
+
+    next(err)
+  }
+}
+
+exports.delete = async (req, res, next) => {
+  try {
+    const id = req.params.id
+    const numberRowsAffected = await Sale.destroy({ where: { id } })
+
+    if (numberRowsAffected !== 1) {
+      const err = new Error()
+      err.message = `No se puede actualizar el elemento con la id=${id}. Tal vez no se ha encontrado.`
+      err.statusCode = 404
+      throw err
+    }
+
+    res.status(200).send({
+      message: 'El elemento ha sido borrado correctamente.'
+    })
+  } catch (err) {
+    next(err)
+  }
+}

--- a/api/src/migrations/202504301226-create-sales-table.js
+++ b/api/src/migrations/202504301226-create-sales-table.js
@@ -1,0 +1,46 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('sales', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false
+      },
+      totalBasePrice: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false
+      },
+      totalTax: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false
+      },
+      totalPrice: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false
+      },
+      issueDate: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      deletedAt: {
+        type: Sequelize.DATE
+      }
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('sales')
+  }
+}

--- a/api/src/models/sequelize/sale.js
+++ b/api/src/models/sequelize/sale.js
@@ -1,0 +1,65 @@
+module.exports = function (sequelize, DataTypes) {
+  const Model = sequelize.define('Sale',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false
+      },
+      totalBasePrice: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false
+      },
+      totalTax: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false
+      },
+      totalPrice: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false
+      },
+      issueDate: {
+        type: DataTypes.DATE,
+        allowNull: false
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        get () {
+          return this.getDataValue('createdAt')
+            ? this.getDataValue('createdAt').toISOString().split('T')[0]
+            : null
+        }
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        get () {
+          return this.getDataValue('updatedAt')
+            ? this.getDataValue('updatedAt').toISOString().split('T')[0]
+            : null
+        }
+      }
+    }, {
+      sequelize,
+      tableName: 'sales',
+      timestamps: true,
+      paranoid: true,
+      indexes: [
+        {
+          name: 'PRIMARY',
+          unique: true,
+          using: 'BTREE',
+          fields: [
+            { name: 'id' }
+          ]
+        }
+      ]
+    }
+  )
+
+  Model.associate = function (models) {
+
+  }
+
+  return Model
+}

--- a/api/src/routes/admin/sales.js
+++ b/api/src/routes/admin/sales.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const router = express.Router()
+const controller = require('../../controllers/admin/sale-controller.js')
+
+router.post('/', controller.create)
+router.get('/', controller.findAll)
+router.get('/:id', controller.findOne)
+router.put('/:id', controller.update)
+router.delete('/:id', controller.delete)
+
+module.exports = router

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -4,5 +4,6 @@ const router = express.Router()
 router.use('/admin/users', require('./admin/users'))
 router.use('/admin/customers', require('./admin/customers'))
 router.use('/admin/bots', require('./admin/bots'))
+router.use('/admin/sales', require('./admin/sales'))
 
 module.exports = router


### PR DESCRIPTION
## Summary
- add migration for `sales` table
- implement Sequelize `Sale` model
- create controller and routes for sales
- register sales routes

## Testing
- `npm --prefix api test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68400bb7a6c48330824a7e53c5df2905